### PR TITLE
SyslogNG Backtick Crash

### DIFF
--- a/Docker/syslog-ng.conf
+++ b/Docker/syslog-ng.conf
@@ -58,7 +58,7 @@ destination d_newscrit { file("/var/log/news/news.crit"); };
 destination d_newserr { file("/var/log/news/news.err"); };
 destination d_newsnotice { file("/var/log/news/news.notice"); };
 
-# Some `catch-all' logfiles.
+# Some 'catch-all' logfiles.
 #
 destination d_debug { file("/var/log/debug"); };
 destination d_error { file("/var/log/error"); };


### PR DESCRIPTION
Replacing backtick in syslogng.conf that was causing the initialise to crash