### PR TITLE
Preventing a crash and allowing configuration to specify 'db: Null'

### DIFF
--- a/docassemble_base/docassemble/base/config.py
+++ b/docassemble_base/docassemble/base/config.py
@@ -122,7 +122,7 @@ def load(**kwargs):
         AZURE_ENABLED = False
     else:
         AZURE_ENABLED = True
-    if 'db' not in daconfig:
+    if 'db' not in daconfig or daconfig['db'] is None:
         daconfig['db'] = dict(name="docassemble", user="docassemble", password="abc123")
     # for key in [['DBPREFIX', 'prefix'], ['DBNAME', 'name'], ['DBUSER', 'user'], ['DBPASSWORD', 'password'], ['DBHOST', 'host'], ['DBPORT', 'port'], ['DBTABLEPREFIX', 'table prefix']]:
     #     if key[0] in os.environ:


### PR DESCRIPTION
If db: Null is specified in config.yml then it causes a config load crash.