### PR TITLE
Disabling watchdog in supervisor. initialize.sh will launch watchdog …

### DIFF
--- a/Docker/docassemble-supervisor.conf
+++ b/Docker/docassemble-supervisor.conf
@@ -31,7 +31,7 @@ priority=50
 [program:watchdog]
 command=/usr/share/docassemble/local/bin/python -m docassemble.webapp.watchdog
 user=0
-autostart=true
+autostart=false
 autorestart=true
 exitcodes=0
 startsecs=1

--- a/Docker/initialize.sh
+++ b/Docker/initialize.sh
@@ -775,6 +775,10 @@ fi
 
 echo "51" >&2
 
+if [ "${WATCHDOGENABLE:-true}" == "true" ]; then
+    supervisorctl start watchdog
+fi
+
 function deregister() {
     su -c "source $DA_ACTIVATE && python -m docassemble.webapp.deregister $DA_CONFIG_FILE" www-data
     if [ "${S3ENABLE:-false}" == "true" ]; then


### PR DESCRIPTION
…by default, with the option of setting WATCHDOGENABLE=false as an env var to disable this.